### PR TITLE
set json request header to avoid errors in es6+

### DIFF
--- a/add_replica.sh
+++ b/add_replica.sh
@@ -8,8 +8,10 @@ replica_count="${replica_count:-1}"
 
 echo "setting replica count to $replica_count on $index_name index in $cluster_url"
 
-curl -XPUT "$cluster_url/$index_name/_settings" -d "{
-        \"index\" : {
-                \"number_of_replicas\" : $replica_count
-        }
+curl -XPUT "$cluster_url/$index_name/_settings" \
+  -H 'Content-Type: application/json' \
+  -d "{
+  \"index\" : {
+    \"number_of_replicas\" : $replica_count
+  }
 }"

--- a/count_types.sh
+++ b/count_types.sh
@@ -6,7 +6,9 @@ echo "counting all types on $cluster_url"
 
 # query for all source values with an aggregation
 # this requires fielddata to be loaded, which takes a bit of memory
-curl -s -XPOST "$cluster_url/pelias/_search?size=0" -d '{
+curl -s -XPOST "$cluster_url/pelias/_search?size=0" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "aggs" : {
     "source_count" : { "terms" : { "field" : "source" } }
   }
@@ -15,7 +17,9 @@ curl -s -XPOST "$cluster_url/pelias/_search?size=0" -d '{
 
 # query for all layer values with an aggregation
 # this requires fielddata to be loaded, which takes a bit of memory
-curl -s -XPOST "$cluster_url/pelias/_search?size=0" -d '{
+curl -s -XPOST "$cluster_url/pelias/_search?size=0" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "aggs" : {
     "layer_count" : { "terms" : { "field" : "layer", "size": 20 } }
   }

--- a/enable_slowlog.sh
+++ b/enable_slowlog.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 cluster_url="${cluster_url:-http://localhost:9200}"
 echo "enabling slowlog for searching and indexing on $cluster_url"
 
-curl -XPUT "$cluster_url/_cluster/settings" -d '{
+curl -XPUT "$cluster_url/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "persistent": {
     "index.search.slowlog.threshold.query.warn": "10s",
     "index.search.slowlog.threshold.query.info": "5s",

--- a/increase_bulk_thread_pool.sh
+++ b/increase_bulk_thread_pool.sh
@@ -3,4 +3,6 @@ set -eu
 
 cluster_url="${cluster_url:-http://localhost:9200}"
 echo "setting threadpool.bulk.queue_size to 500 on $cluster_url"
-curl -XPUT ${cluster_url}/_cluster/settings -d '{ "transient" : { "threadpool.bulk.queue_size" : 500 } }'
+curl -XPUT ${cluster_url}/_cluster/settings \
+  -H 'Content-Type: application/json' \
+  -d '{ "transient" : { "threadpool.bulk.queue_size" : 500 } }'

--- a/load_snapshot.sh
+++ b/load_snapshot.sh
@@ -14,7 +14,9 @@ new_snapshot_name="${new_snapshot_name:-pelias-2017.11.18-001123}"
 read_only="${read_only:-true}"
 
 # create bucket, only needs to be run once
-curl -XPOST "$cluster_url/_snapshot/$es_repo_name" -d "{
+curl -XPOST "$cluster_url/_snapshot/$es_repo_name" \
+  -H 'Content-Type: application/json' \
+  -d "{
  \"type\": \"s3\",
    \"settings\": {
    \"bucket\": \"$s3_bucket\",
@@ -26,7 +28,9 @@ curl -XPOST "$cluster_url/_snapshot/$es_repo_name" -d "{
 }"
 
 ## import new snapshot with name including timestamp
-curl -XPOST "$cluster_url/_snapshot/$es_repo_name/${new_snapshot_name}/_restore" -d "{
+curl -XPOST "$cluster_url/_snapshot/$es_repo_name/${new_snapshot_name}/_restore" \
+  -H 'Content-Type: application/json' \
+  -d "{
   \"indices\": \"pelias\",
   \"rename_pattern\": \"pelias\",
   \"rename_replacement\": \"$new_snapshot_name\"

--- a/make_alias.sh
+++ b/make_alias.sh
@@ -6,7 +6,9 @@ index_name="${index_name:-pelias-2017.11.18-001123}"
 
 echo "setting pelias alias to $index_name on $cluster_url"
 
-curl -XPOST "$cluster_url/_aliases" -d "{
+curl -XPOST "$cluster_url/_aliases" \
+  -H 'Content-Type: application/json' \
+  -d "{
   \"actions\": [{
     \"add\": {
 	  \"index\": \"$index_name\",

--- a/make_cluster_read_only.sh
+++ b/make_cluster_read_only.sh
@@ -4,7 +4,9 @@ set -ue
 
 cluster_url="${cluster_url:-http://localhost:9200}"
 
-curl -s -XPUT "$cluster_url/_cluster/settings" -d '{
+curl -s -XPUT "$cluster_url/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "persistent" : {
     "cluster.blocks.read_only" : true
   }

--- a/make_cluster_read_write.sh
+++ b/make_cluster_read_write.sh
@@ -4,7 +4,9 @@ set -ue
 
 cluster_url="${cluster_url:-http://localhost:9200}"
 
-curl -s -XPUT "$cluster_url/_cluster/settings" -d '{
+curl -s -XPUT "$cluster_url/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "persistent" : {
     "cluster.blocks.read_only" : false
   }

--- a/make_snapshot.sh
+++ b/make_snapshot.sh
@@ -22,7 +22,9 @@ s3_bucket="${s3_bucket:-pelias-elasticsearch.nextzen.org}"
 
 # create Elasticsearch repository from settings
 set -x
-curl -XPOST "$cluster_url/_snapshot/$es_repo_name" -d "{
+curl -XPOST "$cluster_url/_snapshot/$es_repo_name" \
+  -H 'Content-Type: application/json' \
+  -d "{
  \"type\": \"s3\",
    \"settings\": {
    \"bucket\": \"$s3_bucket\",
@@ -32,7 +34,9 @@ curl -XPOST "$cluster_url/_snapshot/$es_repo_name" -d "{
 }"
 
 # create snapshot
-curl -XPUT "$cluster_url/_snapshot/$es_repo_name/$new_snapshot_name" -d '{
+curl -XPUT "$cluster_url/_snapshot/$es_repo_name/$new_snapshot_name" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "indices": "pelias"
 }'
 

--- a/test/test_create_index.sh
+++ b/test/test_create_index.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-curl -XPUT "$cluster_url/twitter?pretty" -H 'Content-Type: application/json' -d'
-{
-    "settings" : {
-        "index" : {
-            "number_of_shards" : 3,
-            "number_of_replicas" : 2
-        }
+curl -XPUT "$cluster_url/twitter?pretty" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "settings" : {
+    "index" : {
+      "number_of_shards" : 3,
+      "number_of_replicas" : 2
     }
-}
-'
+  }
+}'
 
 curl -XDELETE "$cluster_url/twitter"

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 cluster_url="${cluster_url:-http://localhost:9200}"
 echo "setting optimal index recovery settings for higher performance on $cluster_url"
 
-curl -XPUT "$cluster_url/_cluster/settings" -d '{
+curl -XPUT "$cluster_url/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "persistent": {
     "indices.recovery.max_bytes_per_sec": "4000mb",
     "cluster.routing.allocation.node_concurrent_recoveries": 24,

--- a/update_watermarks.sh
+++ b/update_watermarks.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 cluster_url="${cluster_url:-http://localhost:9200}"
 echo "setting disk watermark levels for $cluster_url"
 
-curl -XPUT "$cluster_url/_cluster/settings" -d '{
+curl -XPUT "$cluster_url/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d '{
   "persistent": {
     "cluster.routing.allocation.disk.watermark.low": "95%",
     "cluster.routing.allocation.disk.watermark.high": "95%"


### PR DESCRIPTION
This PR explicitly sets the `Content-Type` header for all JSON requests to Elasticsearch.
These headers are required in ES6+ where [strict content-type checking](https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests) is enforced.

related to https://github.com/geocodeearth/terraform/pull/76

I had to create a fork in order to open a PR and it seemed wrong to PR from `missinglink->orangejulius` so I created it on the `geocodeearth` org.

I think it might be a good idea to have scripts used in our production scripts to live under the `geocodearth` org, but I'm not sure how best to deal with the duplication, maybe we sync between the two or maybe we down-scale to one copy?

```bash
+ git clone https://github.com/orangejulius/elasticsearch-bash-utils.git
Cloning into 'elasticsearch-bash-utils'...
+ cd elasticsearch-bash-utils
+ bash count_types.sh
counting all types on http://localhost:9200
{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}
```